### PR TITLE
fix(build): update script path in GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Build
       run: |
         set -x
-        CI="" ./sdk/docker-solana/build.sh
+        CI="" ./docker-solana/build.sh
         docker tag anzaxyz/agave:"${CI_TAG}" ghcr.io/kilnfi/jito-solana:"${CI_TAG}"
         docker push ghcr.io/kilnfi/jito-solana:"${CI_TAG}"
       env:


### PR DESCRIPTION
TL;DR: Corrected the build script path to ensure the workflow runs as intended.

Description: The GitHub Actions build workflow has been updated to reference the correct directory for the build script. The previously used path './sdk/docker-solana/build.sh' was erroneous, and it has now been adjusted to './docker-solana/build.sh'. This fix ensures that the CI process locates and executes the build script properly. 🎉

Key Changes:
- Change build command to execute './docker-solana/build.sh' instead of './sdk/docker-solana/build.sh'
- Maintain docker tag and push workflow commands